### PR TITLE
fix(dependabot): ignores nx packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,6 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "chore(deps): "
+    ignore:
+      # Ignore all nx-related packages (these must be updated with nx migrate)
+      - dependency-name: "@nrwl/*"


### PR DESCRIPTION
## Description
Nx packages must be upgraded with `nx migrate`, so dependabot should ignore them.
## Story or defect related

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
